### PR TITLE
feat: Add periodic image capture and server communication

### DIFF
--- a/front-end/static/js/app.js
+++ b/front-end/static/js/app.js
@@ -1,0 +1,75 @@
+let videoStream = null;
+let captureInterval = 20000; // Capture every 15 seconds
+
+// Function to start the camera, capture an image, and stop the camera
+function captureImage() {
+    // Request access to the user's camera
+    navigator.mediaDevices.getUserMedia({ video: true })
+    .then(stream => {
+        videoStream = stream;
+
+        // Get the video element to display the stream (optional, can be hidden)
+        const videoElement = document.getElementById('video');
+        videoElement.srcObject = stream;
+        videoElement.play();
+
+        // When the video is ready, capture the image
+        videoElement.onloadedmetadata = () => {
+            // Capture the image using a canvas
+            const canvas = document.getElementById('canvas');
+            const context = canvas.getContext('2d');
+            canvas.width = videoElement.videoWidth;
+            canvas.height = videoElement.videoHeight;
+            context.drawImage(videoElement, 0, 0, canvas.width, canvas.height);
+
+            // Convert the canvas content (image) to base64 format
+            const imageData = canvas.toDataURL('image/png');
+
+            // Send the image to the server (implement this in Flask)
+            sendImageToServer(imageData);
+
+            // Stop the camera to save battery
+            stopCamera();
+        };
+    })
+    .catch(err => {
+        console.error("Error accessing the camera: ", err);
+    });
+}
+
+// Function to stop the camera
+function stopCamera() {
+    if (videoStream) {
+        const tracks = videoStream.getTracks();
+        tracks.forEach(track => track.stop()); // Stop all video tracks
+        videoStream = null;
+    }
+}
+
+// Function to send the image data to the server
+function sendImageToServer(imageData) {
+    fetch('/process_image', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ image: imageData })
+    })
+    .then(response => response.json())
+    .then(data => {
+        console.log('Drowsiness detection result:', data.result);
+    })
+    .catch(error => {
+        console.error('Error sending image:', error);
+    });
+}
+
+// Function to start the periodic capture process
+function startPeriodicCapture() {
+    captureImage(); // Capture immediately on page load
+    setInterval(captureImage, captureInterval); // Capture every 15 seconds
+}
+
+// Start the periodic capture when the page loads
+window.onload = startPeriodicCapture;
+


### PR DESCRIPTION
This commit adds functionality to capture images periodically from the user's camera and send them to the server for processing. The captured image is converted to base64 format and sent as JSON data using a POST request. The server response is logged to the console.

The capture interval is set to 15 seconds, and the camera is stopped after capturing each image to save battery. The capture process starts immediately when the page loads.

issue #9